### PR TITLE
[BUGFIX] Fix NameError in /health endpoint - Add missing quotes to dictionary key

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,7 +90,7 @@ async def read_root():
 async def health_check():
     """서버 헬스체크 엔드포인트입니다."""
     return {
-        status: "healthy",  # 의도적 버그: "status" 키에 따옴표 누락
+        "status": "healthy",
         "message": "서버가 정상적으로 실행중입니다."
     }
 


### PR DESCRIPTION
## 🐛 버그 수정

### 🔗 관련 이슈
Closes #2

### 🏗️ 변경 유형
- [x] 🐛 버그 수정 (Bug fix)
- [x] ✅ 테스트 통과 (Tests pass)
- [x] 🚫 Breaking change 없음 (Non-breaking change)

---

## 📋 문제 요약

`/health` 엔드포인트에서 딕셔너리 키 `status`에 따옴표가 누락되어 `NameError: name 'status' is not defined` 오류가 발생했습니다.

### 🔍 원인 분석
- Python에서 딕셔너리 키는 반드시 문자열(따옴표 포함) 또는 유효한 변수명이어야 함
- `status`가 정의되지 않은 변수로 인식되어 런타임 에러 발생
- 헬스체크 엔드포인트 완전 실패로 서비스 모니터링 불가

---

## 🔧 수정 내용

### 📁 변경된 파일
- `backend/app/main.py` - health_check() 함수 수정

### 🛠️ 구체적 수정사항

**Before (버그):**
```python
@app.get("/health", tags=["Health"])
async def health_check():
    return {
        status: "healthy",  # ❌ 따옴표 누락
        "message": "서버가 정상적으로 실행중입니다."
    }
```

**After (수정):**
```python
@app.get("/health", tags=["Health"])
async def health_check():
    return {
        "status": "healthy",  # ✅ 따옴표 추가
        "message": "서버가 정상적으로 실행중입니다."
    }
```

---

## 🧪 테스트 결과

### ✅ 수정 전 테스트 실패
```bash
FAILED tests/test_fastapi_app.py::test_health_endpoint - NameError: name 'status' is not defined
======================================= 1 failed, 35 passed in 0.50s =======================================
```

### ✅ 수정 후 테스트 성공
```bash
tests/test_fastapi_app.py::test_health_endpoint PASSED                [100%]
============================================ 36 passed in 0.23s ============================================
```

### 🎯 검증된 기능
- [x] `/health` 엔드포인트 정상 응답
- [x] 기존 모든 테스트 통과 (36/36)
- [x] JSON 응답 형식 올바름
- [x] 다른 엔드포인트에 영향 없음

---

## 📊 예상 응답

수정 후 `/health` 엔드포인트는 다음과 같이 정상 응답합니다:

```json
{
  "status": "healthy",
  "message": "서버가 정상적으로 실행중입니다."
}
```

---

## 🎯 영향 및 효과

### ✅ 긍정적 효과
- **서비스 모니터링 복구**: 헬스체크 엔드포인트 정상 동작
- **CI/CD 파이프라인 정상화**: 모든 테스트 통과
- **안정성 향상**: 런타임 에러 제거
- **사용자 경험 개선**: API 신뢰성 복구

### 🚫 Side Effects
- 없음 (단순 문법 오류 수정)
- 기존 기능에 영향 없음
- Breaking change 없음

---

## 🔍 리뷰 포인트

### 🎯 중점 확인 사항
- [x] 딕셔너리 키 문법 올바른지 확인
- [x] JSON 응답 형식 정확한지 확인
- [x] 테스트 통과 여부 확인
- [x] 다른 엔드포인트 영향 없음 확인

### ⚡ 빠른 검증 방법
```bash
# 1. 로컬 테스트 실행
python -m pytest tests/test_fastapi_app.py::test_health_endpoint -v

# 2. 서버 실행 후 엔드포인트 호출
curl http://localhost:8000/health

# 3. 전체 테스트 실행
python -m pytest tests/ -v
```

---

## 📝 추가 정보

### 🏷️ 메타데이터
- **브랜치**: `bugfix/health-endpoint-syntax-error`
- **커밋 해시**: `7f1b47b`
- **수정 시간**: 약 5분
- **테스트 시간**: 약 2분

### 🔄 배포 준비도
- [x] 코드 수정 완료
- [x] 테스트 통과 확인
- [x] 문서화 완료
- [x] 사이드 이펙트 없음 확인

---

**이 PR은 긴급 버그 수정이므로 빠른 리뷰 및 머지를 요청드립니다!** 🚨

### 🤝 리뷰어
- 자동 할당된 리뷰어의 승인 후 즉시 머지 가능
- 단순 문법 오류 수정으로 위험도 낮음

---

**Thank you for the quick review!** 🙏